### PR TITLE
Remove pods/log from RBAC

### DIFF
--- a/deploy/k8s-v1.20/chkk-cronjob.yaml
+++ b/deploy/k8s-v1.20/chkk-cronjob.yaml
@@ -34,7 +34,6 @@ rules:
       - ""
     resources:
       - pods
-      - pods/log
       - podtemplates
       - replicationcontrollers
       - services

--- a/deploy/k8s-v1.21/chkk-cronjob.yaml
+++ b/deploy/k8s-v1.21/chkk-cronjob.yaml
@@ -34,7 +34,6 @@ rules:
       - ""
     resources:
       - pods
-      - pods/log
       - podtemplates
       - replicationcontrollers
       - services


### PR DESCRIPTION
## Description

- Remove `pod/logs` from RBAC for Cluster Guard