### PR TITLE
added manifest for >= v.18

### DIFF
--- a/deploy/k8s-v1.18/chkk-cronjob.yaml
+++ b/deploy/k8s-v1.18/chkk-cronjob.yaml
@@ -1,0 +1,286 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chkk-system
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-cronjob
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-cronjob
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-cronjob
+  namespace: chkk-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-cronjob
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-cronjob
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-cronjob
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - podtemplates
+      - replicationcontrollers
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - statefulsets
+      - daemonsets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-cronjob
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-cronjob
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-cronjob
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chkk-cluster-context-cronjob
+subjects:
+  - kind: ServiceAccount
+    name: chkk-cluster-context-cronjob
+    namespace: chkk-system
+---
+apiVersion: v1
+data:
+  clusterguard.config: |-
+    DaemonSet: true
+    Deployment: true
+    Pod: true
+    PodTemplate: true
+    ReplicationController: true
+    StatefulSet: true
+    NetworkPolicy: true
+    CronJob: true
+    Namespace: true
+    Service: true
+    Job: true
+    Ingress: true
+    ConfigMap: true
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-cronjob
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-cronjob
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-cronjob
+  namespace: chkk-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-cronjob
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-cronjob
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-cronjob
+  namespace: chkk-system
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-cronjob
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-cronjob
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-cronjob
+  namespace: chkk-system
+spec:
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: chkk-cluster-context-cronjob
+        app.kubernetes.io/name: chkk-cluster-context-cronjob
+      annotations:
+        chkk.io/name: ClusterGuard
+        chkk.io/version: v1.0.15
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: chkk-cluster-context-cronjob
+            app.kubernetes.io/name: chkk-cluster-context-cronjob
+          annotations:
+            chkk.io/name: ClusterGuard
+            chkk.io/version: v1.0.15
+        spec:
+          automountServiceAccountToken: true
+          containers:
+            - env:
+                - name: CHKK_ACCESS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: CHKK_ACCESS_TOKEN
+                      name: chkk-access-token
+              image: public.ecr.aws/j8z4q9j4/chkk-kontext:latest
+              imagePullPolicy: Always
+              name: chkk-cluster-context-cronjob
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 500m
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - mountPath: /config
+                  name: chkk-cluster-context-cronjob
+                  readOnly: true
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 12000
+          serviceAccountName: chkk-cluster-context-cronjob
+          volumes:
+            - configMap:
+                name: chkk-cluster-context-cronjob
+              name: chkk-cluster-context-cronjob
+  schedule: 0 */12 * * *
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/instance: chkk-cluster-context-firstscan-job
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/name: chkk-cluster-context-firstscan-job
+  annotations:
+    chkk.io/name: ClusterGuard
+    chkk.io/version: v1.0.15
+  name: chkk-cluster-context-firstscan-job
+  namespace: chkk-system
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: chkk-cluster-context-firstscan-job
+        app.kubernetes.io/name: chkk-cluster-context-firstscan-job
+      annotations:
+        chkk.io/name: ClusterGuard
+        chkk.io/version: v1.0.15
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - env:
+            - name: CHKK_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CHKK_ACCESS_TOKEN
+                  name: chkk-access-token
+          image: public.ecr.aws/j8z4q9j4/chkk-kontext:latest
+          imagePullPolicy: Always
+          name: chkk-cluster-context-firstscan-job
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /config
+              name: chkk-cluster-context-firstscan-job
+              readOnly: true
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 12000
+      serviceAccountName: chkk-cluster-context-cronjob
+      volumes:
+        - configMap:
+            name: chkk-cluster-context-cronjob
+          name: chkk-cluster-context-firstscan-job


### PR DESCRIPTION
## Issue

- closes https://github.com/chkk-io/sprints/issues/325

## Description of changes

- added manifest for k8s v1.18 and below, with no `seccompProfile` field

## Checklist

- [ ] Added/modified documentation as required (such as the ``` README.md ``` etc)
- [x] Manually tested. Describe what testing was done in the testing section below
- [ ] Make sure the title of the PR is a good description that can go into the release notes

## Testing

- applied on a cluster and installation went through